### PR TITLE
adding extract_batch_dag

### DIFF
--- a/dags/extract_batch_dag.py
+++ b/dags/extract_batch_dag.py
@@ -1,0 +1,110 @@
+import time
+import datetime
+from airflow import DAG
+from airflow.decorators import task_group
+from airflow.operators.dummy_operator import DummyOperator
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.dagrun_operator import TriggerDagRunOperator
+
+from fetch_data.fetch_binance_batch import fetch_binance_batch
+from fetch_data.fetch_yf_batch import fetch_yf_batch
+from upload_data.upload_to_s3 import upload_to_s3
+
+################################################
+### 바이낸스, 야후 파이낸스 API 활용해 가격, 지수 
+### 배치 데이터 추출해 S3에 업로드 하는 DAG
+### 매일 10시에 실행 
+################################################
+
+# 야후 파이낸스 API 추출용 심볼 및 S3 저장 경로 정의
+yf_symbols_and_keys = [
+    ('^GSPC', 'raw/s&p500.csv'),
+    ('^IXIC', 'raw/nasdaq.csv'),
+    ('GC=F', 'raw/gold.csv'),
+    ('DX-Y.NYB', 'raw/dollar.csv'),
+    ('^VIX', 'raw/vix.csv'),
+]
+
+# DAG 설정
+default_args = {
+    'owner': 'airflow',
+    'start_date': datetime.datetime(2024, 12, 23),
+    'retries': 1,
+}
+
+# 바이낸스 데이터 추출 후 업로드 시키는 함수
+def upload_binance_task(ti):
+    upload_to_s3(
+        data=ti.xcom_pull(task_ids='binance.fetch_binance_batch', key='binance_batch'),
+        s3_key="raw/btc_usdt_data.csv"
+    )
+
+# 야후 파이낸스스 데이터 추출 후 업로드 시키는 함수
+def upload_yf_task(ti, yf_symbol, s3_key):
+    upload_to_s3(
+        data=ti.xcom_pull(
+            task_ids=f"yf.fetch_yf_batch_{yf_symbol.replace('^', '').replace('=', '')}",
+            key=f'{yf_symbol}_batch'    # 복수의 심볼 사용으로 상단에 정의한 딕셔너리 참조
+        ),
+        s3_key=s3_key
+    )
+
+# DAG 정의
+with DAG(
+    dag_id = 'extract_batch_dag',
+    default_args=default_args,
+    description='A DAG to fetch batch data and upload to S3',
+    schedule_interval='0 10 * * *',
+    catchup=False,
+    tags=['batch', 'S3'],
+) as dag:
+
+    # DummyOperator로 start와 end 정의
+    start = DummyOperator(task_id='start')
+    end = DummyOperator(task_id='end')
+
+    # 바이낸스 데이터 추출 -> 업로드 Task Group
+    @task_group
+    def binance():
+        fetch_binance_batch_task = PythonOperator(
+            task_id='fetch_binance_batch',
+            python_callable=fetch_binance_batch,
+        )
+
+        upload_binance_batch_task = PythonOperator(
+            task_id='upload_binance_batch',
+            python_callable=upload_binance_task,
+        )
+
+        fetch_binance_batch_task >> upload_binance_batch_task
+
+    # 야후 파이낸스 데이터 추출 -> 업로드 Task Group
+    @task_group
+    def yf():
+        for yf_symbol, yf_s3_key in yf_symbols_and_keys:
+            sanitized_symbol = yf_symbol.replace("^", "").replace("=", "")
+            fetch_yf_task_id = f'fetch_yf_batch_{sanitized_symbol}'
+            upload_yf_task_id = f'upload_yf_batch_{sanitized_symbol}'
+
+            fetch_yf_batch_task = PythonOperator(
+                task_id=fetch_yf_task_id,
+                python_callable=fetch_yf_batch,
+                op_kwargs={'symbol': yf_symbol},
+            )
+
+            upload_yf_batch_task = PythonOperator(
+                task_id=upload_yf_task_id,
+                python_callable=upload_yf_task,
+                op_kwargs={'yf_symbol': yf_symbol, 's3_key': yf_s3_key},
+            )
+
+            fetch_yf_batch_task >> upload_yf_batch_task
+
+    # daily 배치(훈련) 데이터 로드 작업 완료시 training DAG를 Trigger
+    trigger_training_task = TriggerDagRunOperator(
+        task_id='trigger_training',
+        trigger_dag_id='training_dag',  # 트리거할 DAG ID
+    )
+
+    # 전체 Task 종속성
+    start >> [binance(), yf()] >> trigger_training_task >> end


### PR DESCRIPTION
**추가하려는 DAG 파일명:** 
- extract_batch_dag.py

**DAG 기능 정의:**
- 바이낸스, 야후 파이낸스 API 활용해 
  코인 가격, 주가 지수 등의 배치 데이터 추출해 S3에 업로드하는 DAG
- 매일 10시에 실행하고 배치 추출 완료 후 training DAG를 trigger 하고 종료
- 한 번에 19년 1월 1일 ~ 어제, 약 6년치 추출해 
추후 전처리 및 훈련 데이터로 사용하는 목적

**Task Flow:**   
- start >> [binance(), yf()] >> trigger_training_task >> end

1. 바이낸스, 야후(yf) 두 Task Group 이 병렬로 실행되어 
오류 발생 시 효율적으로 특정 그룹 또는 Task 재실행 가능
2. 데이터 추출 -> 업로드 작업 완료 후 
trigger_training_task가 training DAG를 trigger 하고 본 DAG 종료
3. fetch_binance_batch, fetch_yf_batch, upload_to_s3 
세 개 함수를 모듈화해 작성하고 
본 DAG로 Import 해 실행함으로써 가독성을 높이고, 
함수 수정 및 재사용이 용이하도록 구현하였음
 ---
![2025-01-09 10 30 56](https://github.com/user-attachments/assets/c488a7aa-fa60-4e25-9b54-0999a56d4c61)
